### PR TITLE
Added cache url param to avoid cached version requests

### DIFF
--- a/src/Plugin.LatestVersion.Android/LatestVersionImplementation.cs
+++ b/src/Plugin.LatestVersion.Android/LatestVersionImplementation.cs
@@ -58,7 +58,7 @@ namespace Plugin.LatestVersion
             }
 
             var version = string.Empty;
-			// Use cache parameter to prevent caching
+            // Use cache parameter to prevent caching
             var url = $"https://play.google.com/store/apps/details?id={appName}&hl=en&cache={Guid.NewGuid()}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))

--- a/src/Plugin.LatestVersion.Android/LatestVersionImplementation.cs
+++ b/src/Plugin.LatestVersion.Android/LatestVersionImplementation.cs
@@ -58,7 +58,8 @@ namespace Plugin.LatestVersion
             }
 
             var version = string.Empty;
-            var url = $"https://play.google.com/store/apps/details?id={appName}&hl=en";
+			// Use cache parameter to prevent caching
+            var url = $"https://play.google.com/store/apps/details?id={appName}&hl=en&cache={Guid.NewGuid()}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {

--- a/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
+++ b/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
@@ -54,8 +54,8 @@ namespace Plugin.LatestVersion
             }
 
             var version = string.Empty;
-			// Use cache parameter to prevent caching
-			var url = $"http://itunes.apple.com/lookup?bundleId={appName}&cache={Guid.NewGuid()}";
+            // Use cache parameter to prevent caching
+            var url = $"http://itunes.apple.com/lookup?bundleId={appName}&cache={Guid.NewGuid()}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {

--- a/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
+++ b/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
@@ -54,7 +54,8 @@ namespace Plugin.LatestVersion
             }
 
             var version = string.Empty;
-            var url = $"http://itunes.apple.com/lookup?bundleId={appName}";
+			// Use cache parameter to prevent caching
+			var url = $"http://itunes.apple.com/lookup?bundleId={appName}&cache={Guid.NewGuid()}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {


### PR DESCRIPTION
### Changes proposed in this pull request:  
- Added &cache=GUID parameter to GetLatestVersionNumber request. AppStore and Google Play cache these requests and this prevents getting an old version number when a new version is available in the store.
