### PR TITLE
Allows users to set a country for iOS. When an app is only published …

### DIFF
--- a/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
+++ b/src/Plugin.LatestVersion.iOS/LatestVersionImplementation.cs
@@ -16,6 +16,8 @@ namespace Plugin.LatestVersion
         string _bundleIdentifier => NSBundle.MainBundle.ObjectForInfoDictionary("CFBundleIdentifier").ToString();
         string _bundleVersion => NSBundle.MainBundle.ObjectForInfoDictionary("CFBundleShortVersionString").ToString();
 
+        public string CountryCode { get; set; }
+
         /// <inheritdoc />
         public string InstalledVersionNumber
         {
@@ -54,7 +56,7 @@ namespace Plugin.LatestVersion
             }
 
             var version = string.Empty;
-            var url = $"http://itunes.apple.com/lookup?bundleId={appName}";
+            var url = string.IsNullOrWhiteSpace(CountryCode) ? $"http://itunes.apple.com/lookup?bundleId={appName}" : $"http://itunes.apple.com/{CountryCode}/lookup?bundleId={appName}";
 
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {


### PR DESCRIPTION
…to one country the default returns no results.


### Changes proposed in this pull request:  
- When an app is only published in one country the version checking fails for iOS
- To resolve this users can set this in the AppDelegate 

((LatestVersionImplementation) CrossLatestVersion.Current).CountryCode = "NZ";
