### PR TITLE
add NewTask flag to avoid crash

### DIFF
--- a/src/LatestVersion.android.cs
+++ b/src/LatestVersion.android.cs
@@ -97,7 +97,8 @@ namespace Plugin.LatestVersion
             }
             catch (ActivityNotFoundException)
             {
-                var intent = new Intent(Intent.ActionView, Net.Uri.Parse($"https://play.google.com/store/apps/details?id={_packageName}"));
+                var intent = new Intent(Intent.ActionView, Net.Uri.Parse($"https://play.google.com/store/apps/details?id={_packageName}"));				
+                intent.SetFlags(ActivityFlags.NewTask);
                 Application.Context.StartActivity(intent);
             }
 


### PR DESCRIPTION
Fixes the following error: 'Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?'

Saw this happen on a simulator that did not have the PlayStore installed. Probably something that will not happen on real devices but you never know.