### PR TITLE
Fix for IOS applications that available in specific country

### DIFF
--- a/src/CrossLatestVersion.shared.cs
+++ b/src/CrossLatestVersion.shared.cs
@@ -21,7 +21,19 @@ namespace Plugin.LatestVersion
             return new LatestVersionImplementation();
 #endif
         }
+        
+        private static string _IosAppCountryAlpha2Code = "";
 
+        /// <summary>
+        /// Needs to be set for IOS application that available only in specific country.
+        /// </summary>
+        /// <value>Alpha 2 code of IOS Application that available in specific country.</value>
+        public static string IosAppCountryAlpha2Code
+        {
+            set => _IosAppCountryAlpha2Code = value + "/";
+            internal get => _IosAppCountryAlpha2Code;
+        }
+        
         /// <summary>
         /// Checks if the plugin is supported on the current platform.
         /// </summary>

--- a/src/LatestVersion.ios.cs
+++ b/src/LatestVersion.ios.cs
@@ -81,7 +81,7 @@ namespace Plugin.LatestVersion
             try
             {
                 var http = new HttpClient();
-                var response = await http.GetAsync($"http://itunes.apple.com/lookup?bundleId={_bundleIdentifier}");
+                var response = await http.GetAsync($"http://itunes.apple.com/{CrossLatestVersion.IosAppCountryAlpha2Code}lookup?bundleId={_bundleIdentifier}");
                 var content = response.Content == null ? null : await response.Content.ReadAsStringAsync();
                 var appLookup = JsonValue.Parse(content);
 


### PR DESCRIPTION
Fixes # .  
If an IOS app is available only in specific country,  IsLatestVersion function throw an exception, and there are no ability specify an IOS app country's alpha 2 code for correct work of that function.
### Changes proposed in this pull request:  
- 
- 
- 
