### PR TITLE
Country code property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.1.0-beta] - 2021-04-06
 
 ### Added
-- Added optional `CountryCode` property. GitHub issue [#25](https://github.com/edsnider/LatestVersionPlugin/issues/25)
+- Added optional `CountryCode` property. GitHub issues [#15](https://github.com/edsnider/LatestVersionPlugin/issues/15), [#25](https://github.com/edsnider/LatestVersionPlugin/issues/25)
 
 ## [2.0.0] - 2020-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.1.0-beta] - 2021-04-06
+
+### Added
+- Added optional `CountryCode` property. GitHub issue [#25](https://github.com/edsnider/LatestVersionPlugin/issues/25)
+
 ## [2.0.0] - 2020-02-25
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ Open the current running app in the public store:
 await CrossLatestVersion.Current.OpenAppInStore();
 ```
 
+### Set country code
+
+Set the country code to be used when looking up the current app in the public store:
+
+```csharp
+CrossLatestVersion.Current.CountryCode = "nz";
+```
+
+Notes about the `CountryCode` property:
+- It is optional; if not provided it will default to "us".
+- It is only needed/used on iOS. 
+- If used, the value should be an alpha-2 code (ISO 3166-1). 
+
 ## Example
 
 ```csharp

--- a/src/ILatestVersion.shared.cs
+++ b/src/ILatestVersion.shared.cs
@@ -9,6 +9,12 @@ namespace Plugin.LatestVersion.Abstractions
     public interface ILatestVersion
     {
         /// <summary>
+        /// Gets and sets the country code to use when looking up the app in the public store.
+        /// Note: This is currently only needed/used by the Apple implementations (defaults to "us")
+        /// </summary>
+        string CountryCode { get; set; }
+
+        /// <summary>
         /// Gets the version number of the current app's installed version.
         /// </summary>
         /// <value>The current app's installed version number.</value>

--- a/src/LatestVersion.android.cs
+++ b/src/LatestVersion.android.cs
@@ -21,6 +21,9 @@ namespace Plugin.LatestVersion
         string _versionName => Application.Context.PackageManager.GetPackageInfo(Application.Context.PackageName, 0).VersionName;
 
         /// <inheritdoc />
+        public string CountryCode { get; set; }
+
+        /// <inheritdoc />
         public string InstalledVersionNumber
         {
             get => _versionName;

--- a/src/LatestVersion.ios.cs
+++ b/src/LatestVersion.ios.cs
@@ -24,6 +24,9 @@ namespace Plugin.LatestVersion
         string _bundleVersion => NSBundle.MainBundle.ObjectForInfoDictionary("CFBundleShortVersionString").ToString();
 
         /// <inheritdoc />
+        public string CountryCode { get; set; } = "us";
+
+        /// <inheritdoc />
         public string InstalledVersionNumber
         {
             get => _bundleVersion;
@@ -78,10 +81,12 @@ namespace Plugin.LatestVersion
 
         async Task<App> LookupApp()
         {
+            var countryCode = string.IsNullOrWhiteSpace(CountryCode) ? "us" : CountryCode;
+
             try
             {
                 using var http = new HttpClient();
-                var response = await http.GetAsync($"http://itunes.apple.com/lookup?bundleId={_bundleIdentifier}");
+                var response = await http.GetAsync($"http://itunes.apple.com/{countryCode}/lookup?bundleId={_bundleIdentifier}");
                 var content = response.Content == null ? null : await response.Content.ReadAsStringAsync();
                 var appLookup = JsonValue.Parse(content);
 

--- a/src/LatestVersion.uwp.cs
+++ b/src/LatestVersion.uwp.cs
@@ -14,6 +14,9 @@ namespace Plugin.LatestVersion
         string _packageVersion => Package.Current.Id.Version.ToVersionString();
 
         /// <inheritdoc />
+        public string CountryCode { get; set; }
+
+        /// <inheritdoc />
         public string InstalledVersionNumber
         {
             get => _packageVersion;


### PR DESCRIPTION
Fixes #25 
Fixes #15 

### Changes proposed in this pull request:  
- Added `CountryCode` property to `ILatestVersion`. 
  - iOS implementation: Used in itunes `/lookup` call.  Should be provided as an alpha-2 code (ISO 3166-1); defaults to "us". 
  - Android implementation: Not used
  - UWP implementation: Not used
